### PR TITLE
Expose write failures in flush

### DIFF
--- a/examples/lwt/dune
+++ b/examples/lwt/dune
@@ -1,7 +1,7 @@
 (executables
  (libraries h1 h1-lwt-unix h1_examples base stdio lwt lwt.unix)
  (optional true)
- (names lwt_get lwt_post lwt_echo_post lwt_echo_upgrade))
+ (names lwt_get lwt_post lwt_echo_post lwt_echo_upgrade lwt_chunked))
 
 (alias
  (name runtest)

--- a/examples/lwt/lwt_chunked.ml
+++ b/examples/lwt/lwt_chunked.ml
@@ -1,0 +1,40 @@
+open Base
+open Lwt.Infix
+module Arg = Stdlib.Arg
+
+open H1_lwt_unix
+
+let request_handler (_ : Unix.sockaddr) reqd =
+  let body = H1.Reqd.respond_with_streaming reqd (H1.Response.create ~headers:(H1.Headers.of_list ["connection", "close"]) `OK) in
+  let rec respond_loop i =
+    H1.Body.Writer.write_string body (Printf.sprintf "Chunk %i\n" i);
+    H1.Body.Writer.flush_with_reason body (function
+    | `Closed  -> Stdio.print_endline "closed"
+    | `Written -> Stdio.print_endline "written"; Lwt.bind (Lwt_unix.sleep 5.) (fun () -> respond_loop (i+1)) |> ignore
+    );
+    Lwt.return_unit
+  in ignore (respond_loop 0)
+
+let error_handler (_ : Unix.sockaddr) = H1_examples.Server.error_handler
+
+let main port =
+  let listen_address = Unix.(ADDR_INET (inet_addr_loopback, port)) in
+  Lwt.async (fun () ->
+    Lwt_io.establish_server_with_client_socket
+      listen_address
+      (Server.create_connection_handler ~upgrade_handler:None ~request_handler ~error_handler)
+    >|= fun _server ->
+      Stdio.printf "Listening on port %i.\n" port);
+  let forever, _ = Lwt.wait () in
+  Lwt_main.run forever
+;;
+
+let () =
+  Stdlib.Sys.set_signal Stdlib.Sys.sigpipe Stdlib.Sys.Signal_ignore;
+  let port = ref 8080 in
+  Arg.parse
+    ["-p", Arg.Set_int port, " Listening port number (8080 by default)"]
+    ignore
+    "Echoes POST requests. Runs forever.";
+  main !port
+;;

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -102,18 +102,20 @@ module Reader = struct
 end
 
 module Writer = struct
+  module Writer = Serialize.Writer
+
   type encoding =
     | Identity
     | Chunked of { mutable written_final_chunk : bool }
 
   type t =
-    { faraday             : Faraday.t
-    ; encoding            : encoding
-    ; when_ready_to_write : unit -> unit
-    ; buffered_bytes      : int ref
+    { faraday        : Faraday.t
+    ; writer         : Writer.t
+    ; encoding       : encoding
+    ; buffered_bytes : int ref
     }
 
-  let of_faraday faraday ~encoding ~when_ready_to_write =
+  let of_faraday faraday writer ~encoding =
     let encoding =
       match encoding with
       | `Fixed _ | `Close_delimited -> Identity
@@ -121,33 +123,56 @@ module Writer = struct
     in
     { faraday
     ; encoding
-    ; when_ready_to_write
+    ; writer
     ; buffered_bytes = ref 0
     }
 
-  let create buffer ~encoding ~when_ready_to_write =
-    of_faraday (Faraday.of_bigstring buffer) ~encoding ~when_ready_to_write
+  let create buffer writer ~encoding =
+    of_faraday (Faraday.of_bigstring buffer) writer ~encoding
 
   let write_char t c =
-    Faraday.write_char t.faraday c
+    if not (Faraday.is_closed t.faraday) then
+      Faraday.write_char t.faraday c
 
   let write_string t ?off ?len s =
-    Faraday.write_string ?off ?len t.faraday s
+    if not (Faraday.is_closed t.faraday) then
+      Faraday.write_string ?off ?len t.faraday s
 
   let write_bigstring t ?off ?len b =
-    Faraday.write_bigstring ?off ?len t.faraday b
+    if not (Faraday.is_closed t.faraday) then
+      Faraday.write_bigstring ?off ?len t.faraday b
 
   let schedule_bigstring t ?off ?len (b:Bigstringaf.t) =
-    Faraday.schedule_bigstring ?off ?len t.faraday b
+    if not (Faraday.is_closed t.faraday) then
+      Faraday.schedule_bigstring ?off ?len t.faraday b
 
-  let ready_to_write t = t.when_ready_to_write ()
+  let ready_to_write t = Writer.wakeup t.writer
 
   let flush t kontinue =
     Faraday.flush t.faraday kontinue;
     ready_to_write t
 
+  let flush_with_reason t kontinue =
+    if Writer.is_closed t.writer then
+      kontinue `Closed
+    else begin
+      Faraday.flush_with_reason t.faraday (fun reason ->
+        let result =
+          match reason with
+          | Nothing_pending | Shift -> `Written
+          | Drain -> `Closed
+        in
+        kontinue result);
+      ready_to_write t
+    end
+
   let is_closed t =
     Faraday.is_closed t.faraday
+
+  let close_and_drain t =
+    Faraday.close t.faraday;
+    (* Resolve all pending flushes *)
+    ignore (Faraday.drain t.faraday : int)
 
   let close t =
     Faraday.close t.faraday;
@@ -166,33 +191,39 @@ module Writer = struct
     in
     faraday_has_output || additional_encoding_output
 
-  let transfer_to_writer t writer =
+  let transfer_to_writer t =
     let faraday = t.faraday in
-    begin match Faraday.operation faraday with
-    | `Yield -> ()
-    | `Close ->
-      (match t.encoding with
-       | Identity -> ()
-       | Chunked ({ written_final_chunk } as chunked) ->
-         if not written_final_chunk then begin
-           chunked.written_final_chunk <- true;
-           Serialize.Writer.schedule_chunk writer [];
-         end);
-      Serialize.Writer.unyield writer;
-    | `Writev iovecs ->
-      let buffered = t.buffered_bytes in
-      begin match IOVec.shiftv iovecs !buffered with
-      | []     -> ()
-      | iovecs ->
-        let lengthv  = IOVec.lengthv iovecs in
-        buffered := !buffered + lengthv;
-        begin match t.encoding with
-        | Identity  -> Serialize.Writer.schedule_fixed writer iovecs
-        | Chunked _ -> Serialize.Writer.schedule_chunk writer iovecs
-        end;
-        Serialize.Writer.flush writer (fun () ->
-          Faraday.shift faraday lengthv;
-          buffered := !buffered - lengthv)
-      end
+    if Writer.is_closed t.writer then
+      close_and_drain t
+    else begin
+      match Faraday.operation faraday with
+      | `Yield -> ()
+      | `Close ->
+        (match t.encoding with
+         | Identity -> ()
+         | Chunked ({ written_final_chunk } as chunked) ->
+           if not written_final_chunk then begin
+             chunked.written_final_chunk <- true;
+             Serialize.Writer.schedule_chunk t.writer [];
+           end);
+        Serialize.Writer.unyield t.writer;
+      | `Writev iovecs ->
+        let buffered = t.buffered_bytes in
+        begin match IOVec.shiftv iovecs !buffered with
+        | []     -> ()
+        | iovecs ->
+          let lengthv  = IOVec.lengthv iovecs in
+          buffered := !buffered + lengthv;
+          begin match t.encoding with
+          | Identity  -> Serialize.Writer.schedule_fixed t.writer iovecs
+          | Chunked _ -> Serialize.Writer.schedule_chunk t.writer iovecs
+          end;
+          Serialize.Writer.flush t.writer (fun result ->
+            match result with
+            | `Closed -> close_and_drain t
+            | `Written ->
+              Faraday.shift faraday lengthv;
+              buffered := !buffered - lengthv)
+        end
     end
 end

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -71,8 +71,8 @@ module Oneshot = struct
         | `Error `Bad_request ->
           failwith "H1.Client_connection.request: invalid body length"
       in
-      Body.Writer.create (Bigstringaf.create config.request_body_buffer_size)
-        ~encoding ~when_ready_to_write:(fun () -> Writer.wakeup writer)
+      Body.Writer.create (Bigstringaf.create config.request_body_buffer_size) writer
+        ~encoding
     in
     let t =
       { request
@@ -89,7 +89,7 @@ module Oneshot = struct
 
   let flush_request_body t =
     if Body.Writer.has_pending_output t.request_body
-    then Body.Writer.transfer_to_writer t.request_body t.writer
+    then Body.Writer.transfer_to_writer t.request_body
   ;;
 
   let set_error_and_handle_without_shutdown t error =

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -175,8 +175,7 @@ let unsafe_respond_with_streaming ~flush_headers_immediately t response =
               "H1.Reqd.respond_with_streaming: invalid response body length"
       in
       let response_body =
-        Body.Writer.create t.response_body_buffer ~encoding
-          ~when_ready_to_write:(fun () -> Writer.wakeup t.writer)
+        Body.Writer.create t.response_body_buffer t.writer ~encoding
       in
       Writer.write_response t.writer response;
       if t.persistent then
@@ -288,6 +287,5 @@ let flush_request_body t =
 
 let flush_response_body t =
   match t.response_state with
-  | Streaming (_, response_body) ->
-      Body.Writer.transfer_to_writer response_body t.writer
+  | Streaming (_, response_body) -> Body.Writer.transfer_to_writer response_body
   | _ -> ()

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -177,8 +177,9 @@ let set_error_and_handle ?request t error =
                 "H1.Server_connection.error_handler: invalid response body \
                  length"
         in
-        Body.Writer.of_faraday (Writer.faraday writer) ~encoding
-          ~when_ready_to_write:(fun () -> Writer.wakeup writer)))
+        Body.Writer.of_faraday (Writer.faraday writer) writer ~encoding
+    )
+  )
 
 let report_exn t exn = set_error_and_handle t (`Exn exn)
 

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -312,7 +312,7 @@ let echo_handler response reqd =
   let response_body = Reqd.respond_with_streaming reqd response in
   let rec on_read buffer ~off ~len =
     Body.Writer.write_string response_body (Bigstringaf.substring ~off ~len buffer);
-    Body.Writer.flush response_body (fun () ->
+    Body.Writer.flush response_body (fun _ ->
       Body.Reader.schedule_read request_body ~on_eof ~on_read)
   and on_eof () =
     print_endline "echo handler eof";
@@ -332,7 +332,9 @@ let streaming_handler ?(flush=false) response writes reqd =
     | w :: ws ->
       Body.Writer.write_string body w;
       writes := ws;
-      Body.Writer.flush body write
+      Body.Writer.flush_with_reason body (function
+        | `Closed -> ()
+        | `Written -> write ())
   in
   write ();
 ;;
@@ -772,9 +774,11 @@ let test_chunked_encoding () =
     let response = Response.create `OK ~headers:Headers.encoding_chunked in
     let resp_body = Reqd.respond_with_streaming reqd response in
     Body.Writer.write_string resp_body "First chunk";
-    Body.Writer.flush resp_body (fun () ->
-      Body.Writer.write_string resp_body "Second chunk";
-      Body.Writer.close resp_body);
+    Body.Writer.flush_with_reason resp_body (function
+      | `Closed -> assert false
+      | `Written ->
+        Body.Writer.write_string resp_body "Second chunk";
+        Body.Writer.close resp_body);
   in
   let t = create ~error_handler request_handler in
   writer_yielded t;
@@ -801,9 +805,11 @@ let test_chunked_encoding_for_error () =
       `Bad_request error;
     let body = start_response Headers.encoding_chunked in
     Body.Writer.write_string body "Bad";
-    Body.Writer.flush body (fun () ->
-      Body.Writer.write_string body " request";
-      Body.Writer.close body);
+    Body.Writer.flush_with_reason body (function
+      | `Closed -> assert false
+      | `Written ->
+        Body.Writer.write_string body " request";
+        Body.Writer.close body);
   in
   let t = create ~error_handler (fun _ -> assert false) in
   let c = feed_string t "  X\r\n\r\n" in
@@ -836,6 +842,53 @@ let test_blocked_write_on_chunked_encoding () =
     write_partial_string t ~msg:"first write" response_bytes 16
   in
   write_string t ~msg:"second write" second_write
+;;
+
+let test_body_writing_when_socket_closes () =
+  let response = Response.create `OK ~headers:Headers.encoding_chunked in
+  let body_ref = ref None in
+  let request_handler reqd =
+    let body = Reqd.respond_with_streaming reqd response in
+    body_ref := Some body
+  in
+  let t = create request_handler in
+  writer_yielded t;
+  read_request t (Request.create `GET "/");
+
+  let flush_result_testable =
+    Alcotest.of_pp
+      (Fmt.using (function `Closed -> "Closed" | `Written -> "Written") Fmt.string)
+  in
+
+  let body = Option.get !body_ref in
+  let check_flush ~expect service_writer =
+    let flush_result = ref None in
+    Body.Writer.flush_with_reason body (fun r -> flush_result := Some r);
+    service_writer ();
+    Alcotest.(check' (option flush_result_testable))
+      ~msg:"flush_result is as expected"
+      ~expected:(Some expect)
+      ~actual:!flush_result;
+  in
+
+  Body.Writer.write_string body "First chunk";
+  check_flush (fun () ->
+    write_response t
+      ~msg:"First chunk written"
+      ~body:"b\r\nFirst chunk\r\n"
+      response)
+    ~expect:`Written;
+
+  Body.Writer.write_string body "Second chunk";
+  check_flush (fun () -> write_eof t) ~expect:`Closed;
+
+  (* Writing after the writer is closed does not raise, but flushes get immediately
+     resolved with `Closed. *)
+  Body.Writer.write_string body "Chunk after closed";
+  check_flush (fun () -> ()) ~expect:`Closed;
+
+  Body.Writer.close body;
+  check_flush (fun () -> ()) ~expect:`Closed;
 ;;
 
 let test_unexpected_eof () =
@@ -1267,6 +1320,7 @@ let tests =
   ; "chunked encoding", `Quick, test_chunked_encoding
   ; "chunked encoding for error", `Quick, test_chunked_encoding_for_error
   ; "blocked write on chunked encoding", `Quick, test_blocked_write_on_chunked_encoding
+  ; "body writing when socket closes", `Quick, test_body_writing_when_socket_closes
   ; "writer unexpected eof", `Quick, test_unexpected_eof
   ; "input shrunk", `Quick, test_input_shrunk
   ; "failed request parse", `Quick, test_failed_request_parse


### PR DESCRIPTION
See https://github.com/inhabitedtype/httpaf/pull/217 and https://github.com/ada2k/httpaf/tree/expose-write-failures-in-flush

I've changed this to add back in `flush: t -> (unit -> unit) -> unit` for old code and code that only expects to flush once and so doesn't care about the result.

The original PR changes write_ functions to be guarded behind an if statement, and do nothing instead of raising if the user tries to write to a closed Faraday.t so that this can be properly handled in `flush_with_reason`. I've removed tests that expect for it to raise.

Sidenote: I also have a patch which integrates httpun-types for greater interop between both ocaml-h2 and httpun. LMK if this would be appreciated by h1 :)