### PR TITLE
Move to `bstr`

### DIFF
--- a/examples/lib/h1_examples.ml
+++ b/examples/lib/h1_examples.ml
@@ -6,7 +6,7 @@ let print_string = Stdio.(Out_channel.output_string stdout)
 
 let text = "CHAPTER I. Down the Rabbit-Hole  Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, <and what is the use of a book,> thought Alice <without pictures or conversations?> So she was considering in her own mind (as well as she could, for the hot day made her feel very sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her. There was nothing so very remarkable in that; nor did Alice think it so very much out of the way to hear the Rabbit say to itself, <Oh dear! Oh dear! I shall be late!> (when she thought it over afterwards, it occurred to her that she ought to have wondered at this, but at the time it all seemed quite natural); but when the Rabbit actually took a watch out of its waistcoat-pocket, and looked at it, and then hurried on, Alice started to her feet, for it flashed across her mind that she had never before seen a rabbit with either a waistcoat-pocket, or a watch to take out of it, and burning with curiosity, she ran across the field after it, and fortunately was just in time to see it pop down a large rabbit-hole under the hedge. In another moment down went Alice after it, never once considering how in the world she was to get out again. The rabbit-hole went straight on like a tunnel for some way, and then dipped suddenly down, so suddenly that Alice had not a moment to think about stopping herself before she found herself falling down a very deep well. Either the well was very deep, or she fell very slowly, for she had plenty of time as she went down to look about her and to wonder what was going to happen next. First, she tried to look down and make out what she was coming to, but it was too dark to see anything; then she looked at the sides of the well, and noticed that they were filled with cupboards......"
 
-let text = Bigstringaf.of_string ~off:0 ~len:(String.length text) text
+let text = Bstr.of_string text
 
 module Client = struct
  exception Response_error
@@ -26,7 +26,7 @@ module Client = struct
     | { Response.status = `OK; _ } as response ->
       Format.fprintf Format.std_formatter "%a\n%!" Response.pp_hum response;
       let rec on_read bs ~off ~len =
-        Bigstringaf.substring ~off ~len bs |> print_string;
+        Bstr.sub_string ~off ~len bs |> print_string;
         Body.Reader.schedule_read response_body ~on_read ~on_eof
       in
       Body.Reader.schedule_read response_body ~on_read ~on_eof;
@@ -63,7 +63,7 @@ module Server = struct
   ;;
 
   let benchmark =
-    let headers = Headers.of_list ["content-length", Int.to_string (Bigstringaf.length text)] in
+    let headers = Headers.of_list ["content-length", Int.to_string (Bstr.length text)] in
     let handler reqd =
       let { Request.target; _ } = Reqd.request reqd in
       let request_body          = Reqd.request_body reqd in

--- a/h1.opam
+++ b/h1.opam
@@ -16,7 +16,7 @@ depends: [
   "alcotest" {with-test & >= "1.2.0"}
   "stdio" {with-test}
   "base64"
-  "bigstringaf" {>= "0.4.0"}
+  "bstr"
   "angstrom" {>= "0.14.0"}
   "faraday"  {>= "0.6.1"}
   "httpun-types" {>= "0.1.0"}

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -36,7 +36,7 @@ module Reader = struct
     { faraday                        : Faraday.t
     ; mutable read_scheduled         : bool
     ; mutable on_eof                 : unit -> unit
-    ; mutable on_read                : Bigstringaf.t -> off:int -> len:int -> unit
+    ; mutable on_read                : Bstr.t -> off:int -> len:int -> unit
     }
 
   let default_on_eof         = Sys.opaque_identity (fun () -> ())
@@ -50,7 +50,7 @@ module Reader = struct
     }
 
   let create_empty () =
-    let t = create Bigstringaf.empty in
+    let t = create Bstr.empty in
     Faraday.close t.faraday;
     t
 
@@ -142,7 +142,7 @@ module Writer = struct
     if not (Faraday.is_closed t.faraday) then
       Faraday.write_bigstring ?off ?len t.faraday b
 
-  let schedule_bigstring t ?off ?len (b:Bigstringaf.t) =
+  let schedule_bigstring t ?off ?len (b:Bstr.t) =
     if not (Faraday.is_closed t.faraday) then
       Faraday.schedule_bigstring ?off ?len t.faraday b
 

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -71,7 +71,7 @@ module Oneshot = struct
         | `Error `Bad_request ->
           failwith "H1.Client_connection.request: invalid body length"
       in
-      Body.Writer.create (Bigstringaf.create config.request_body_buffer_size) writer
+      Body.Writer.create (Bstr.create config.request_body_buffer_size) writer
         ~encoding
     in
     let t =

--- a/lib/dune
+++ b/lib/dune
@@ -2,5 +2,5 @@
  (name        h1)
  (public_name h1)
  (libraries
-   angstrom faraday base64 bigstringaf httpun-types)
+   angstrom faraday base64 bstr httpun-types)
  (flags (:standard -safe-string)))

--- a/lib/h1.mli
+++ b/lib/h1.mli
@@ -514,10 +514,11 @@ module Websocket : sig
     val unmask_inplace : t -> unit
     val length : t -> int
     val payload_length : t -> int
-    val with_payload : t -> f:(Bstr.t -> off:int -> len:int -> 'a) -> 'a
-    val copy_payload : t -> Bstr.t
-    val copy_payload_bytes : t -> Bytes.t
     val parse : t Angstrom.t
+
+    (* does not allocate a bigstring, but instead returns a
+       new view into the frame payload *)
+    val payload_view : t -> Bstr.t
 
     val serialize_control :
       Faraday.t -> mask:int32 option -> opcode:Opcode.standard_control -> unit

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -210,7 +210,7 @@ module Reader = struct
   type 'error parse_state =
     | Done
     | Fail    of 'error
-    | Partial of (Bigstringaf.t -> off:int -> len:int -> AU.more -> (unit, 'error) result AU.state)
+    | Partial of (Bstr.t -> off:int -> len:int -> AU.more -> (unit, 'error) result AU.state)
 
   type 'error t =
     { parser              : (unit, 'error) result Angstrom.t
@@ -243,7 +243,7 @@ module Reader = struct
       | `Fixed _ | `Chunked when Request.is_upgrade request ->
         return (Error (`Bad_request request))
       | `Fixed _ | `Chunked as encoding ->
-        let request_body = Body.Reader.create Bigstringaf.empty in
+        let request_body = Body.Reader.create Bstr.empty in
         handler request request_body;
         body ~encoding request_body *> ok
     in
@@ -265,7 +265,7 @@ module Reader = struct
       | `Fixed _ | `Chunked | `Close_delimited as encoding ->
         (* We do not trust the length provided in the [`Fixed] case, as the
            client could DOS easily. *)
-        let response_body = Body.Reader.create Bigstringaf.empty in
+        let response_body = Body.Reader.create Bstr.empty in
         handler response response_body;
         body ~encoding response_body *> ok
     in

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -92,7 +92,7 @@ type t = {
   request : Request.t;
   request_body : Body.Reader.t;
   writer : Writer.t;
-  response_body_buffer : Bigstringaf.t;
+  response_body_buffer : Bstr.t;
   error_handler : error_handler;
   mutable persistent : bool;
   mutable response_state : Response_state.t;
@@ -147,7 +147,7 @@ let respond_with_string t response str =
   | Fixed _ ->
     failwith "H1.Reqd.respond_with_string: response already complete"
 
-let respond_with_bigstring t response (bstr : Bigstringaf.t) =
+let respond_with_bigstring t response (bstr : Bstr.t) =
   if t.error_code <> `Ok then
     failwith
       "H1.Reqd.respond_with_bigstring: invalid state, currently handling error";

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -78,18 +78,18 @@ let write_string_chunk t chunk =
   write_crlf         t
 
 let write_bigstring_chunk t chunk =
-  write_chunk_length t (Bigstringaf.length chunk);
+  write_chunk_length t (Bstr.length chunk);
   write_bigstring    t chunk;
   write_crlf         t
 
 let schedule_bigstring_chunk t chunk =
-  write_chunk_length t (Bigstringaf.length chunk);
+  write_chunk_length t (Bstr.length chunk);
   schedule_bigstring t chunk;
   write_crlf         t
 
 module Writer = struct
   type t =
-    { buffer                : Bigstringaf.t
+    { buffer                : Bstr.t
     (* The buffer that the encoder uses for buffered writes. Managed by the
      * control module for the encoder. *)
     ; encoder               : Faraday.t
@@ -105,7 +105,7 @@ module Writer = struct
     }
 
   let create ?(buffer_size=0x800) () =
-    let buffer = Bigstringaf.create buffer_size in
+    let buffer = Bstr.create buffer_size in
     let encoder = Faraday.of_bigstring buffer in
     { buffer
     ; encoder

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -54,7 +54,7 @@ type error_handler =
 type t = {
   reader : Reader.request;
   writer : Writer.t;
-  response_body_buffer : Bigstringaf.t;
+  response_body_buffer : Bstr.t;
   request_handler : request_handler;
   error_handler : error_handler;
   request_queue : Reqd.t Queue.t;
@@ -102,7 +102,7 @@ let create ?(config = Config.default) ?(error_handler = default_error_handler)
   let { Config.response_buffer_size; response_body_buffer_size; _ } = config in
   let writer = Writer.create ~buffer_size:response_buffer_size () in
   let request_queue = Queue.create () in
-  let response_body_buffer = Bigstringaf.create response_body_buffer_size in
+  let response_body_buffer = Bstr.create response_body_buffer_size in
   let handler request request_body =
     let reqd =
       Reqd.create error_handler request request_body writer response_body_buffer

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -231,7 +231,11 @@ module Frame = struct
     let off = payload_offset t in
     f t ~off ~len
 
-  let copy_payload t = with_payload t ~f:Bstr.copy
+  let copy_payload =
+    let sub_copy t ~off ~len =
+      Bstr.sub t ~off ~len |> Bstr.copy
+    in
+    fun t -> with_payload t ~f:sub_copy
 
   let copy_payload_bytes t =
     with_payload t ~f:(fun bs ~off:src_off ~len ->

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -166,51 +166,51 @@ module Close_code = struct
 end
 
 module Frame = struct
-  type t = Bigstringaf.t
+  type t = Bstr.t
 
   let is_fin t =
-    let bits = Bigstringaf.unsafe_get t 0 |> Char.code in
+    let bits = Bstr.unsafe_get t 0 |> Char.code in
     bits land (1 lsl 7) = 1 lsl 7
 
   let rsv t =
-    let bits = Bigstringaf.unsafe_get t 0 |> Char.code in
+    let bits = Bstr.unsafe_get t 0 |> Char.code in
     (bits lsr 4) land 0b0111
 
   let opcode t =
-    let bits = Bigstringaf.unsafe_get t 0 |> Char.code in
+    let bits = Bstr.unsafe_get t 0 |> Char.code in
     bits land 0b1111 |> Opcode.unsafe_of_code
 
   let payload_length_of_offset t off =
-    let bits = Bigstringaf.unsafe_get t (off + 1) |> Char.code in
+    let bits = Bstr.unsafe_get t (off + 1) |> Char.code in
     let length = bits land 0b01111111 in
-    if length = 126 then Bigstringaf.unsafe_get_int16_be t (off + 2)
+    if length = 126 then Bstr.unsafe_get_int16_be t (off + 2)
     else if
       (* This is technically unsafe, but if somebody's asking us to read 2^63
        * bytes, then we're already screwd. *)
       length = 127
-    then Bigstringaf.unsafe_get_int64_be t (off + 2) |> Int64.to_int
+    then Bstr.unsafe_get_int64_be t (off + 2) |> Int64.to_int
     else length
 
   let payload_length t = payload_length_of_offset t 0
 
   let has_mask t =
-    let bits = Bigstringaf.unsafe_get t 1 |> Char.code in
+    let bits = Bstr.unsafe_get t 1 |> Char.code in
     bits land (1 lsl 7) = 1 lsl 7
 
   let mask t =
     if not (has_mask t) then None
     else
       Some
-        (let bits = Bigstringaf.unsafe_get t 1 |> Char.code in
-         if bits = 254 then Bigstringaf.unsafe_get_int32_be t 4
-         else if bits = 255 then Bigstringaf.unsafe_get_int32_be t 10
-         else Bigstringaf.unsafe_get_int32_be t 2)
+        (let bits = Bstr.unsafe_get t 1 |> Char.code in
+         if bits = 254 then Bstr.unsafe_get_int32_be t 4
+         else if bits = 255 then Bstr.unsafe_get_int32_be t 10
+         else Bstr.unsafe_get_int32_be t 2)
 
   let mask_exn t =
-    let bits = Bigstringaf.unsafe_get t 1 |> Char.code in
-    if bits = 254 then Bigstringaf.unsafe_get_int32_be t 4
-    else if bits = 255 then Bigstringaf.unsafe_get_int32_be t 10
-    else if bits >= 127 then Bigstringaf.unsafe_get_int32_be t 2
+    let bits = Bstr.unsafe_get t 1 |> Char.code in
+    if bits = 254 then Bstr.unsafe_get_int32_be t 4
+    else if bits = 255 then Bstr.unsafe_get_int32_be t 10
+    else if bits >= 127 then Bstr.unsafe_get_int32_be t 2
     else failwith "Frame.mask_exn: no mask present"
 
   let payload_offset_of_bits bits =
@@ -223,7 +223,7 @@ module Frame = struct
     initial_offset + mask_offset + length_offset
 
   let payload_offset t =
-    let bits = Bigstringaf.unsafe_get t 1 |> Char.code in
+    let bits = Bstr.unsafe_get t 1 |> Char.code in
     payload_offset_of_bits bits
 
   let with_payload t ~f =
@@ -231,16 +231,16 @@ module Frame = struct
     let off = payload_offset t in
     f t ~off ~len
 
-  let copy_payload t = with_payload t ~f:Bigstringaf.copy
+  let copy_payload t = with_payload t ~f:Bstr.copy
 
   let copy_payload_bytes t =
     with_payload t ~f:(fun bs ~off:src_off ~len ->
         let bytes = Bytes.create len in
-        Bigstringaf.blit_to_bytes bs ~src_off bytes ~dst_off:0 ~len;
+        Bstr.blit_to_bytes bs ~src_off bytes ~dst_off:0 ~len;
         bytes)
 
   let length_of_offset t off =
-    let bits = Bigstringaf.unsafe_get t (off + 1) |> Char.code in
+    let bits = Bstr.unsafe_get t (off + 1) |> Char.code in
     let payload_offset = payload_offset_of_bits bits in
     let payload_length = payload_length_of_offset t off in
     payload_offset + payload_length
@@ -250,11 +250,11 @@ module Frame = struct
   let apply_mask mask bs ~off ~len =
     for i = off to off + len - 1 do
       let j = (i - off) mod 4 in
-      let c = Bigstringaf.unsafe_get bs i |> Char.code in
+      let c = Bstr.unsafe_get bs i |> Char.code in
       let c =
         c lxor Int32.(logand (shift_right mask (8 * (3 - j))) 0xffl |> to_int)
       in
-      Bigstringaf.unsafe_set bs i (Char.unsafe_chr c)
+      Bstr.unsafe_set bs i (Char.unsafe_chr c)
     done
 
   let apply_mask_bytes mask bs ~off ~len =
@@ -279,7 +279,7 @@ module Frame = struct
   let parse =
     let open Angstrom in
     Unsafe.peek 2 (fun bs ~off ~len:_ -> length_of_offset bs off) >>= fun len ->
-    Unsafe.take len Bigstringaf.sub
+    Unsafe.take len Bstr.sub
 
   let serialize_headers faraday ~mask ~is_fin ~opcode ~payload_length =
     let opcode = Opcode.to_int opcode in
@@ -326,7 +326,7 @@ module Frame = struct
 end
 
 type frame_handler =
-  opcode:Opcode.t -> is_fin:bool -> Bigstringaf.t -> off:int -> len:int -> unit
+  opcode:Opcode.t -> is_fin:bool -> Bstr.t -> off:int -> len:int -> unit
 
 type input_handlers = { frame_handler : frame_handler; eof : unit -> unit }
 
@@ -412,7 +412,7 @@ module Reader = struct
   type 'error parse_state =
     | Done
     | Fail of 'error
-    | Partial of (Bigstringaf.t -> off:int -> len:int -> AU.more -> unit AU.state)
+    | Partial of (Bstr.t -> off:int -> len:int -> AU.more -> unit AU.state)
 
   type 'error t = {
     parser : unit Angstrom.t;

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -183,12 +183,12 @@ module Frame = struct
   let payload_length_of_offset t off =
     let bits = Bstr.unsafe_get t (off + 1) |> Char.code in
     let length = bits land 0b01111111 in
-    if length = 126 then Bstr.unsafe_get_int16_be t (off + 2)
+    if length = 126 then Bstr.get_int16_be t (off + 2)
     else if
       (* This is technically unsafe, but if somebody's asking us to read 2^63
        * bytes, then we're already screwd. *)
       length = 127
-    then Bstr.unsafe_get_int64_be t (off + 2) |> Int64.to_int
+    then Bstr.get_int64_be t (off + 2) |> Int64.to_int
     else length
 
   let payload_length t = payload_length_of_offset t 0
@@ -202,15 +202,15 @@ module Frame = struct
     else
       Some
         (let bits = Bstr.unsafe_get t 1 |> Char.code in
-         if bits = 254 then Bstr.unsafe_get_int32_be t 4
-         else if bits = 255 then Bstr.unsafe_get_int32_be t 10
-         else Bstr.unsafe_get_int32_be t 2)
+         if bits = 254 then Bstr.get_int32_be t 4
+         else if bits = 255 then Bstr.get_int32_be t 10
+         else Bstr.get_int32_be t 2)
 
   let mask_exn t =
     let bits = Bstr.unsafe_get t 1 |> Char.code in
-    if bits = 254 then Bstr.unsafe_get_int32_be t 4
-    else if bits = 255 then Bstr.unsafe_get_int32_be t 10
-    else if bits >= 127 then Bstr.unsafe_get_int32_be t 2
+    if bits = 254 then Bstr.get_int32_be t 4
+    else if bits = 255 then Bstr.get_int32_be t 10
+    else if bits >= 127 then Bstr.get_int32_be t 2
     else failwith "Frame.mask_exn: no mask present"
 
   let payload_offset_of_bits bits =

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,5 +1,5 @@
 (tests
- (libraries bigstringaf h1 alcotest)
+ (libraries h1 alcotest)
  (modules
    helpers
    test_client_connection

--- a/lib_test/helpers.ml
+++ b/lib_test/helpers.ml
@@ -33,17 +33,17 @@ module Read_operation = struct
 end
 
 module Write_operation = struct
-  type t = [ `Write of Bigstringaf.t IOVec.t list | `Yield | `Close of int | `Upgrade ]
+  type t = [ `Write of Bstr.t IOVec.t list | `Yield | `Close of int | `Upgrade ]
 
   let iovecs_to_string iovecs =
     let len = IOVec.lengthv iovecs in
     let bytes = Bytes.create len in
     let dst_off = ref 0 in
     List.iter (fun { IOVec.buffer; off = src_off; len } ->
-      Bigstringaf.unsafe_blit_to_bytes buffer ~src_off bytes ~dst_off:!dst_off ~len;
+      Bstr.blit_to_bytes buffer ~src_off bytes ~dst_off:!dst_off ~len;
       dst_off := !dst_off + len)
     iovecs;
-    Bytes.unsafe_to_string bytes
+    Bytes.to_string bytes
   ;;
 
   let pp_hum fmt (t : t) =

--- a/lib_test/test_client_connection.ml
+++ b/lib_test/test_client_connection.ml
@@ -26,7 +26,7 @@ end
 
 let feed_string t str =
   let len = String.length str in
-  let input = Bigstringaf.of_string str ~off:0 ~len in
+  let input = Bstr.of_string str in
   read t input ~off:0 ~len
 
 let read_string t str =
@@ -114,7 +114,7 @@ let test_get () =
   Body.Writer.close body;
   write_request  t request';
   read_response  t response;
-  let c = read_eof t Bigstringaf.empty ~off:0 ~len:0 in
+  let c = read_eof t Bstr.empty ~off:0 ~len:0 in
   Alcotest.(check int) "read_eof with no input returns 0" 0 c;
   connection_is_shutdown t;
 
@@ -169,7 +169,7 @@ let test_response_eof () =
   write_request  t request';
   writer_closed  t;
   reader_ready t;
-  let c = read_eof t Bigstringaf.empty ~off:0 ~len:0 in
+  let c = read_eof t Bstr.empty ~off:0 ~len:0 in
   Alcotest.(check int) "read_eof with no input returns 0" 0 c;
   connection_is_shutdown t;
   Alcotest.(check (option string)) "unexpected eof"
@@ -304,7 +304,7 @@ let test_schedule_read_with_data_available () =
     let did_read = ref false in
     Body.Reader.schedule_read body
       ~on_read:(fun buf ~off ~len ->
-        let actual = Bigstringaf.substring buf ~off ~len in
+        let actual = Bstr.sub_string buf ~off ~len in
         did_read := true;
         Alcotest.(check string) "Body" expected actual)
       ~on_eof:(fun () -> assert false);

--- a/lib_test/test_iovec.ml
+++ b/lib_test/test_iovec.ml
@@ -2,7 +2,7 @@ open H1
 open IOVec
 
 (* The length of the buffer is ignored by iovec operations *)
-let buffer = Bigstringaf.empty
+let buffer = Bstr.empty
 
 let test_lengthv () =
   Alcotest.(check int) "lengthv [] = 0"                 (lengthv []) 0;

--- a/lib_test/test_websocket.ml
+++ b/lib_test/test_websocket.ml
@@ -35,7 +35,7 @@ let test_parsing_text_frame () =
   Alcotest.(check int) "payload_length" (Frame.payload_length frame) 11;
   Alcotest.(check int) "length" (Frame.length frame) 17;
   Frame.unmask_inplace frame;
-  let payload = Bytes.to_string (Frame.copy_payload_bytes frame) in
+  let payload = Bstr.to_string (Frame.payload_view frame) in
   Alcotest.(check string) "payload" "1234567890\n" payload
 
 let tests =


### PR DESCRIPTION
PR for issue #7


for reference here is some differences with `bigstringaf` I noticed:

- `Bigstringaf.substring` correspond to `Bstr.sub_string`
- `Bstr` is missing `unsafe_get_*` functions (same as `get_*` except no bounds checking is performed).
- `Bstr` is missing `unsafe_blit`
- `Bigstringaf.of_string` takes `~len` and `~off` argument, unlike `Bstr.of_string`
- `Bigstringaf.copy` takes `~len` and `~off` argument, unlike `Bstr.of_copy`


In this PR I simply used the "safe" version when `bstr` was missing a "unsafe" function.

Also, I added a commit that change the `Websocket.Frame` interface to expose a view corresponding to the frame payload (a `Bstr.sub` with the right offset and length).

Maybe a benchmark should be done?
