### PR TITLE
Fix the last reference of http/af on our ocaml-h1 project

### DIFF
--- a/h1.opam
+++ b/h1.opam
@@ -25,7 +25,7 @@ depends: [
 synopsis:
   "A high-performance, memory-efficient, and scalable web server for OCaml"
 description: """
-http/af implements the HTTP 1.1 specification with respect to parsing,
+h1 implements the HTTP 1.1 specification with respect to parsing,
 serialization, and connection pipelining as a state machine that is agnostic to
 the underlying IO mechanism, and is therefore portable across many platform.
 It uses the Angstrom and Faraday libraries to implement the parsing and


### PR DESCRIPTION
Fix #13, we also should fix `opam-repository`, I will propose a PR soon about that.